### PR TITLE
port to arbor-dev and 0.2.5

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,4 +1,4 @@
 
 [[constraint]]
-  name = "github.com/acm-uiuc/arbor"
-  version = ">=0.2.4, <1.0.0"
+  name = "github.com/arbor-dev/arbor"
+  version = ">=0.2.5, <1.0.0"

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ mkdir -p log/prod
 #																		#
 #																		#
 #########################################################################	
-go get -u github.com/acm-uiuc/arbor/...
+go get -u github.com/arbor-dev/arbor/...
 
 echo Building config
 go install github.com/acm-uiuc/groot-api-gateway/config

--- a/config/config.go.template
+++ b/config/config.go.template
@@ -1,8 +1,8 @@
 package config
 
 import (
-    "github.com/acm-uiuc/arbor/proxy"
-    "github.com/acm-uiuc/arbor/security"
+    "github.com/arbor-dev/arbor/proxy"
+    "github.com/arbor-dev/arbor/security"
 )
 
 //Groot Specific configurations

--- a/server.go
+++ b/server.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
 	"github.com/acm-uiuc/groot-api-gateway/services"
+	"github.com/arbor-dev/arbor"
 )
 
 func main() {

--- a/services/auth.go
+++ b/services/auth.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location

--- a/services/credits.go
+++ b/services/credits.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location

--- a/services/events.go
+++ b/services/events.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location

--- a/services/gigs.go
+++ b/services/gigs.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location
@@ -25,66 +25,66 @@ const GigFormat string = "JSON"
 
 //API Interface
 var GigsRoutes = arbor.RouteCollection{
-    arbor.Route{
-        "ListGigs",
-        "GET",
-        "/gigs",
-        ListGigs,
-    },
-   arbor.Route{
-        "NewGig",
-        "POST",
-        "/gigs",
-        NewGig,
-    },
-   arbor.Route{
-        "GigInfo",
-        "GET",
-        "/gigs/{gig_id}",
-        GigInfo,
-    },
-   arbor.Route{
-        "EditGig",
-        "PUT",
-        "/gigs/{gig_id}",
-        EditGig,
-    },
-   arbor.Route{
-        "DeleteGig",
-        "DELETE",
-        "/gigs/{gig_id}",
-        DeleteGig,
-    },
-    arbor.Route{
-        "ListClaims",
-        "GET",
-        "/gigs/claims",
-        ListClaims,
-    },
-   arbor.Route{
-        "CreateClaim",
-        "POST",
-        "/gigs/claims",
-        CreateClaim,
-    },
-    arbor.Route{
-        "ListSingleClaim",
-        "GET",
-        "/gigs/claims/{claim_id}",
-        ListSingleClaim,
-    },
-    arbor.Route{
-        "AcceptClaim",
-        "PUT",
-        "/gigs/claims/{claim_id}",
-        AcceptClaim,
-    },
-    arbor.Route{
-        "DeleteClaim",
-        "DELETE",
-        "/gigs/claims/{claim_id}",
-        DeleteClaim,
-    },
+	arbor.Route{
+		"ListGigs",
+		"GET",
+		"/gigs",
+		ListGigs,
+	},
+	arbor.Route{
+		"NewGig",
+		"POST",
+		"/gigs",
+		NewGig,
+	},
+	arbor.Route{
+		"GigInfo",
+		"GET",
+		"/gigs/{gig_id}",
+		GigInfo,
+	},
+	arbor.Route{
+		"EditGig",
+		"PUT",
+		"/gigs/{gig_id}",
+		EditGig,
+	},
+	arbor.Route{
+		"DeleteGig",
+		"DELETE",
+		"/gigs/{gig_id}",
+		DeleteGig,
+	},
+	arbor.Route{
+		"ListClaims",
+		"GET",
+		"/gigs/claims",
+		ListClaims,
+	},
+	arbor.Route{
+		"CreateClaim",
+		"POST",
+		"/gigs/claims",
+		CreateClaim,
+	},
+	arbor.Route{
+		"ListSingleClaim",
+		"GET",
+		"/gigs/claims/{claim_id}",
+		ListSingleClaim,
+	},
+	arbor.Route{
+		"AcceptClaim",
+		"PUT",
+		"/gigs/claims/{claim_id}",
+		AcceptClaim,
+	},
+	arbor.Route{
+		"DeleteClaim",
+		"DELETE",
+		"/gigs/claims/{claim_id}",
+		DeleteClaim,
+	},
 }
 
 //Route handler
@@ -105,7 +105,7 @@ func CreateClaim(w http.ResponseWriter, r *http.Request) {
 }
 
 func EditGig(w http.ResponseWriter, r *http.Request) {
-    	arbor.PUT(w, GigsURL+r.URL.String(), GigFormat, "", r)
+	arbor.PUT(w, GigsURL+r.URL.String(), GigFormat, "", r)
 }
 
 func DeleteGig(w http.ResponseWriter, r *http.Request) {

--- a/services/groups.go
+++ b/services/groups.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location

--- a/services/hardware.go
+++ b/services/hardware.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location

--- a/services/memes.go
+++ b/services/memes.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location

--- a/services/merch.go
+++ b/services/merch.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location

--- a/services/notification.go
+++ b/services/notification.go
@@ -11,10 +11,10 @@
 package services
 
 import (
-    "net/http"
+	"net/http"
 
-    "github.com/acm-uiuc/arbor"
-    "github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location
@@ -25,15 +25,15 @@ const NotificationFormat string = "JSON"
 
 //API Interface
 var NotificationRoutes = arbor.RouteCollection{
-    arbor.Route{
-        "PostNotification",
-        "POST",
-        "/notification",
-        PostNotification,
-    },
+	arbor.Route{
+		"PostNotification",
+		"POST",
+		"/notification",
+		PostNotification,
+	},
 }
 
 // arbor.Route handler
 func PostNotification(w http.ResponseWriter, r *http.Request) {
-    arbor.POST(w, NotificationURL+r.URL.String(), NotificationFormat, "", r)
+	arbor.POST(w, NotificationURL+r.URL.String(), NotificationFormat, "", r)
 }

--- a/services/quotes.go
+++ b/services/quotes.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location

--- a/services/recruiters.go
+++ b/services/recruiters.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location

--- a/services/request.go
+++ b/services/request.go
@@ -11,10 +11,10 @@
 package services
 
 import (
-    "net/http"
+	"net/http"
 
-    "github.com/acm-uiuc/arbor"
-    "github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location
@@ -25,30 +25,30 @@ const RequestFormat string = "JSON"
 
 //API Interface
 var RequestRoutes = arbor.RouteCollection{
-    arbor.Route{
-        "PostRequest",
-        "POST",
-        "/request",
-        PostRequest,
-    },
-    arbor.Route{
-        "GetRequest",
-        "GET",
-        "/request",
-        GetRequest,
-    },
-    arbor.Route{
-        "GetRequestByID",
-        "GET",
-        "/request/{id}",
-        GetRequestByID,
-    },
-    arbor.Route{
-        "UpdateRequest",
-        "PUT",
-        "/request/{id}",
-        UpdateRequest,
-    },
+	arbor.Route{
+		"PostRequest",
+		"POST",
+		"/request",
+		PostRequest,
+	},
+	arbor.Route{
+		"GetRequest",
+		"GET",
+		"/request",
+		GetRequest,
+	},
+	arbor.Route{
+		"GetRequestByID",
+		"GET",
+		"/request/{id}",
+		GetRequestByID,
+	},
+	arbor.Route{
+		"UpdateRequest",
+		"PUT",
+		"/request/{id}",
+		UpdateRequest,
+	},
 }
 
 // arbor.Route handler

--- a/services/services.go
+++ b/services/services.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
+	"github.com/arbor-dev/arbor"
 )
 
 var Routes = arbor.RouteCollection{

--- a/services/users.go
+++ b/services/users.go
@@ -13,8 +13,8 @@ package services
 import (
 	"net/http"
 
-	"github.com/acm-uiuc/arbor"
 	"github.com/acm-uiuc/groot-api-gateway/config"
+	"github.com/arbor-dev/arbor"
 )
 
 //Location


### PR DESCRIPTION
This changes dependencies to the arbor-dev variant since it will now be upstream and bumps the version to 0.2.5, handling the issues with go routines, should be good to deploy 